### PR TITLE
Stage 2: 通信層の刷新(react-stomp → @stomp/stompjs)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-stage2-communication.md
+++ b/docs/superpowers/plans/2026-07-04-stage2-communication.md
@@ -763,3 +763,5 @@ git commit -m "react-stompを削除しStage 2検証結果を記録"
 - `useGameSocket` の Minor(enabled=false 時に status が disconnected に戻らない/status 遷移の直接テスト補完)→ Stage 3 で余裕があれば
 - sass @import 非推奨警告、App Router 移行、命名統一等 → Stage 4
 - ライブ再接続ドリル(実ネットワーク断)は手動確認
+- 送信経路の try/catch 非対称(timebomb changeLimitTme/changeSecretFlg)→ Stage 3 の送信整理で統一検討(挙動維持のため現状は据え置き)
+- ConnectionStatus の z-index:9999 がモーダルと重なり得る点は目視確認推奨(一時バナーのみ・低リスク)

--- a/docs/superpowers/plans/2026-07-04-stage2-communication.md
+++ b/docs/superpowers/plans/2026-07-04-stage2-communication.md
@@ -737,11 +737,29 @@ git commit -m "react-stompを削除しStage 2検証結果を記録"
 
 ## 検証記録
 
-(Task 8 実行時に記入)
+### Task 8(2026-07-04)— Stage 2 完了検証
 
-- react-stomp 参照残存: なし / あれば列挙
-- useGameSocket テスト: X件 PASS
-- 全5ゲーム本番接続: 各ゲームの結果
-- 再接続インジケータ動作: 結果
-- 意図的な挙動差分: 接続インジケータの追加のみ(他はなし)
-- 次ステージへの申し送り(Stage 3: 受信ハンドラの reducer 化)
+- **react-stomp 参照残存: なし**(`grep -rn "react-stomp|SockJsClient|clientObj|.sendMessage" src` が 0 件)。`react-stomp` を依存から削除済み
+- **テスト: 11件 PASS**(useGameSocket 8件 + next.config 3件)
+- **lint: error 0**(warning 65 は既存の exhaustive-deps 等、新規なし)/ **build: 成功**(Node 22系→現在は brew 由来 node 26、フラグ不要)
+- **全5ゲーム本番接続(Heroku、Next 15 dev、useGameSocket 経由)**:
+
+| ゲーム | topic | 接続 | 送受信 | コンソールエラー |
+|---|---|---|---|---|
+| timebomb | `/topic/{roomId}/timebomb` | ✅ | ✅ 入室往復(名前表示)確認 | なし |
+| werewolf | `/topic/{roomId}` | ✅ | ✅ /info 発行 | なし |
+| hideout | `/topic/{roomId}` | ✅ | ✅ /info 発行 | なし |
+| decrypt | `/topic/{roomId}` | ✅ | ✅ /info 発行・描画 | なし |
+| fakeartist | `/topic/{roomId}` | ✅ | ✅ /info 発行 | なし |
+
+- **接続インジケータ**: 接続中は非表示(誤表示なし)を確認。表示ロジック(`reconnecting`/`disconnected` のみ表示)は Task 2 で検証済み
+- **再接続**: ユニットテストで status 遷移(`onWebSocketClose`→`reconnecting`)・`reconnectDelay: 5000`・再購読時の旧 subscription 破棄を検証済み。**ライブの強制切断ドリルはヘッドレス環境では未実施**(SockJS が内部で WebSocket 参照を保持するため介入不可)。実ネットワーク断での自動復帰は手動確認推奨
+- **意図的な挙動差分**: 接続インジケータの追加のみ(他はなし)
+
+**判定: Stage 2 完了。** react-stomp を排除し、全5ゲームが型付き共通フック `useGameSocket` 経由で本番バックエンドと送受信できる。
+
+### 既知の残課題(後続ステージへ)
+- 受信ハンドラ(`receve`/`getMessage` の status switch)の reducer 化 → **Stage 3**
+- `useGameSocket` の Minor(enabled=false 時に status が disconnected に戻らない/status 遷移の直接テスト補完)→ Stage 3 で余裕があれば
+- sass @import 非推奨警告、App Router 移行、命名統一等 → Stage 4
+- ライブ再接続ドリル(実ネットワーク断)は手動確認

--- a/docs/superpowers/plans/2026-07-04-stage2-communication.md
+++ b/docs/superpowers/plans/2026-07-04-stage2-communication.md
@@ -1,0 +1,747 @@
+# Stage 2: 通信層の刷新 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `react-stomp` を `@stomp/stompjs` v7 + `sockjs-client` に置換し、型付き共通フック `useGameSocket` に集約して、5ゲーム全てが本番バックエンドと送受信でき、自動再接続と控えめな接続インジケータを備える状態にする。
+
+**Architecture:** `@stomp/stompjs` の `Client` をラップした React フック `useGameSocket` を1つ作り、5ゲームで共用する。各ゲームページは `SockJsClient`(JSX)と `clientObj`/`isConnected` state を、フックの返り値(`status`/`connected`/`send`)に置換するだけ。受信ハンドラ(`receve`/`getMessage` の status switch)は無変更(reducer 化は Stage 3)。バックエンドは無変更で互換維持。
+
+**Tech Stack:** @stomp/stompjs v7 / sockjs-client / Vitest + @testing-library/react (jsdom)
+
+**スコープ注記:** 設計書は `docs/superpowers/specs/2026-07-04-stage2-communication-design.md`。通信層の差し替えに限定。受信ロジックの reducer 化は Stage 3、App Router 移行等は Stage 4。
+
+## Global Constraints
+
+- 作業ブランチ: `refactor/stage2-communication`(master から作成済み)。push / PR 作成はユーザーの指示があるまで行わない
+- 実行ディレクトリ: `frontend/`(モノレポ)。すべての相対パス・bash コマンドは `frontend/` をカレントとする。ただし `docs/...` はリポジトリルート基準(frontend/ からは `../docs/...`)
+- コミットメッセージは日本語の短文。末尾に `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` を付ける
+- **バックエンド仕様は変更不可:** SockJS エンドポイント `boardgame-endpoint`、STOMP 購読トピック(timebomb は `/topic/{roomId}/timebomb`、他4ゲームは `/topic/{roomId}`)、送信宛先 `/app/*`、REST `createroom` の互換を維持
+- ユーザーから見た挙動は概ね維持。追加してよいのは接続インジケータ(再接続中/切断時のみ表示)のみ
+- 受信ハンドラ(各ゲームの `receve`/`getMessage` とその呼び出す setter 群)は**変更しない**
+- 送信は `send(destination, payload)` に統一。**`JSON.stringify` はフック内部で行うため、呼び出し側から `JSON.stringify()` を外す**(二重エンコード防止)
+- Prettier 設定(tabWidth:4 / singleQuote / semi / trailingComma:es5)は変更しない
+- `react-stomp` は全5ゲーム移行が完了する Task 8 まで削除しない
+- Node は v22.21.0。`npm run build`/`dev`/`test` は OpenSSL フラグ不要(Stage 1 で Next 15 化済み)
+
+---
+
+### Task 1: `useGameSocket` フックとテスト基盤
+
+**Files:**
+- Modify: `package.json` / `package-lock.json`(依存追加)
+- Create: `vitest.config.ts`
+- Create: `src/lib/stomp/types.ts`
+- Create: `src/lib/stomp/useGameSocket.ts`
+- Test: `src/lib/stomp/useGameSocket.test.ts`
+
+**Interfaces:**
+- Consumes: `SystemConst.Server.AP_HOST` / `ENDPOINT`(既存 `src/const/next.config.ts`)
+- Produces:
+  - `type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected'`
+  - `useGameSocket(opts: { topic: string; onMessage: (msg: any) => void; enabled: boolean }): { status: ConnectionStatus; connected: boolean; send: (destination: string, payload: unknown) => void }`
+  - Task 2〜7 がこの `useGameSocket` を使う
+
+- [ ] **Step 1: 依存を追加**
+
+```bash
+npm install @stomp/stompjs@^7 sockjs-client@^1
+npm install -D @testing-library/react@^16 @testing-library/dom@^10 jsdom@^25 @types/sockjs-client@^1
+```
+
+Expected: `.npmrc`(legacy-peer-deps=true)下でインストール成功。
+
+- [ ] **Step 2: Vitest に jsdom 環境を設定**
+
+`vitest.config.ts` を新規作成(既存の `next.config.test.ts` は node 環境で問題ないが、フックテストは DOM が要る。グローバルは jsdom にし、DOM 非依存テストも jsdom で問題なく動く):
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+    },
+});
+```
+
+- [ ] **Step 3: 型定義を作成**
+
+`src/lib/stomp/types.ts`:
+
+```ts
+export type ConnectionStatus =
+    | 'connecting'
+    | 'connected'
+    | 'reconnecting'
+    | 'disconnected';
+
+export type GameSocket = {
+    status: ConnectionStatus;
+    connected: boolean;
+    send: (destination: string, payload: unknown) => void;
+};
+```
+
+- [ ] **Step 4: 失敗するテストを書く**
+
+`src/lib/stomp/useGameSocket.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// @stomp/stompjs の Client をモック(生成された各インスタンスを instances に記録)
+vi.mock('@stomp/stompjs', () => {
+    class MockClient {
+        config: any;
+        connected = false;
+        activate = vi.fn();
+        deactivate = vi.fn(() => Promise.resolve());
+        subscribe = vi.fn(() => ({ unsubscribe: vi.fn() }));
+        publish = vi.fn();
+        static instances: any[] = [];
+        constructor(config: any) {
+            this.config = config;
+            MockClient.instances.push(this);
+        }
+        // テスト用: 接続確立を模擬
+        _open() {
+            this.connected = true;
+            this.config.onConnect();
+        }
+        // テスト用: 切断を模擬
+        _close() {
+            this.connected = false;
+            this.config.onWebSocketClose?.();
+        }
+    }
+    return { Client: MockClient };
+});
+
+// sockjs-client は webSocketFactory 内でのみ参照。実接続させないためモック
+vi.mock('sockjs-client', () => ({ default: vi.fn() }));
+
+import { Client } from '@stomp/stompjs';
+import { useGameSocket } from './useGameSocket';
+
+const MockClient = Client as unknown as { instances: any[] };
+
+beforeEach(() => {
+    MockClient.instances.length = 0;
+});
+
+describe('useGameSocket', () => {
+    it('enabled=false の間は Client を生成しない', () => {
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: false })
+        );
+        expect(MockClient.instances.length).toBe(0);
+    });
+
+    it('enabled=true で activate し status は connecting', () => {
+        const { result } = renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        expect(MockClient.instances.length).toBe(1);
+        expect(MockClient.instances[0].activate).toHaveBeenCalled();
+        expect(result.current.status).toBe('connecting');
+        expect(result.current.connected).toBe(false);
+    });
+
+    it('接続確立で status=connected になり、指定 topic を購読する', () => {
+        const { result } = renderHook(() =>
+            useGameSocket({ topic: '/topic/room1', onMessage: () => {}, enabled: true })
+        );
+        act(() => MockClient.instances[0]._open());
+        expect(result.current.status).toBe('connected');
+        expect(result.current.connected).toBe(true);
+        expect(MockClient.instances[0].subscribe).toHaveBeenCalledWith(
+            '/topic/room1',
+            expect.any(Function)
+        );
+    });
+
+    it('受信 body を JSON.parse して onMessage に渡す', () => {
+        const onMessage = vi.fn();
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage, enabled: true })
+        );
+        act(() => MockClient.instances[0]._open());
+        const handler = MockClient.instances[0].subscribe.mock.calls[0][1];
+        act(() => handler({ body: '{"status":200,"turn":1}' }));
+        expect(onMessage).toHaveBeenCalledWith({ status: 200, turn: 1 });
+    });
+
+    it('不正JSONは生文字列で onMessage に渡す', () => {
+        const onMessage = vi.fn();
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage, enabled: true })
+        );
+        act(() => MockClient.instances[0]._open());
+        const handler = MockClient.instances[0].subscribe.mock.calls[0][1];
+        act(() => handler({ body: 'not-json' }));
+        expect(onMessage).toHaveBeenCalledWith('not-json');
+    });
+
+    it('send は接続時に publish(JSON.stringify)、未接続時は例外', () => {
+        const { result } = renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        // 未接続で送信 → 例外
+        expect(() => result.current.send('/app/roomin', { a: 1 })).toThrow();
+        // 接続後 → publish
+        act(() => MockClient.instances[0]._open());
+        act(() => result.current.send('/app/roomin', { a: 1 }));
+        expect(MockClient.instances[0].publish).toHaveBeenCalledWith({
+            destination: '/app/roomin',
+            body: '{"a":1}',
+        });
+    });
+
+    it('再接続(再度の onConnect)で古い subscription を解除してから再購読する', () => {
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        const inst = MockClient.instances[0];
+        act(() => inst._open());
+        const firstSub = inst.subscribe.mock.results[0].value;
+        act(() => inst._close());
+        act(() => inst._open());
+        expect(firstSub.unsubscribe).toHaveBeenCalled();
+        expect(inst.subscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it('アンマウントで deactivate する', () => {
+        const { unmount } = renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        const inst = MockClient.instances[0];
+        unmount();
+        expect(inst.deactivate).toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 5: テストが失敗することを確認**
+
+Run: `npm test`
+Expected: `useGameSocket.test.ts` が FAIL(`useGameSocket` 未実装 / import 解決不可)。`next.config.test.ts` の3件は PASS のまま。
+
+- [ ] **Step 6: フックを実装**
+
+`src/lib/stomp/useGameSocket.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Client, type IMessage, type StompSubscription } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+import { SystemConst } from '../../const/next.config';
+import type { ConnectionStatus, GameSocket } from './types';
+
+type UseGameSocketOptions = {
+    topic: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onMessage: (msg: any) => void;
+    enabled: boolean;
+};
+
+export function useGameSocket(opts: UseGameSocketOptions): GameSocket {
+    const { topic, onMessage, enabled } = opts;
+    const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+    const clientRef = useRef<Client | null>(null);
+    const subRef = useRef<StompSubscription | null>(null);
+
+    // onMessage の最新参照を保持(再接続を誘発しないため deps に入れない)
+    const onMessageRef = useRef(onMessage);
+    onMessageRef.current = onMessage;
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+        let hasConnected = false;
+
+        const client = new Client({
+            webSocketFactory: () =>
+                new SockJS(
+                    SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT
+                ),
+            reconnectDelay: 5000,
+            onConnect: () => {
+                hasConnected = true;
+                setStatus('connected');
+                if (subRef.current) {
+                    try {
+                        subRef.current.unsubscribe();
+                    } catch {
+                        // 破棄済みなら無視
+                    }
+                }
+                subRef.current = client.subscribe(topic, (message: IMessage) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    let parsed: any;
+                    try {
+                        parsed = JSON.parse(message.body);
+                    } catch {
+                        parsed = message.body;
+                    }
+                    onMessageRef.current(parsed);
+                });
+            },
+            onWebSocketClose: () => {
+                setStatus(hasConnected ? 'reconnecting' : 'connecting');
+            },
+        });
+
+        clientRef.current = client;
+        subRef.current = null;
+        setStatus('connecting');
+        client.activate();
+
+        return () => {
+            clientRef.current = null;
+            subRef.current = null;
+            client.deactivate();
+        };
+    }, [topic, enabled]);
+
+    const send = useCallback((destination: string, payload: unknown) => {
+        const client = clientRef.current;
+        if (!client || !client.connected) {
+            throw new Error('Send error: socket is disconnected');
+        }
+        client.publish({ destination, body: JSON.stringify(payload) });
+    }, []);
+
+    return { status, connected: status === 'connected', send };
+}
+```
+
+- [ ] **Step 7: テストが通ることを確認**
+
+Run: `npm test`
+Expected: `useGameSocket.test.ts` の8件 + `next.config.test.ts` の3件、全て PASS。
+
+- [ ] **Step 8: lint とビルドの確認**
+
+Run: `npm run lint && npm run build`
+Expected: lint error 0(warning は可)、build 成功。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.ts src/lib/stomp/
+git commit -m "useGameSocketフックと@stomp/stompjsを導入"
+```
+
+---
+
+### Task 2: 接続インジケータ `ConnectionStatus`
+
+**Files:**
+- Create: `src/components/common/ConnectionStatus.tsx`
+- Create: `src/styles/components/common/connectionstatus.module.scss`
+
+**Interfaces:**
+- Consumes: `ConnectionStatus` 型(`src/lib/stomp/types.ts`)
+- Produces: `ConnectionStatus({ status }: { status: ConnectionStatus })` default export(Task 3〜7 が各ページに設置)
+
+- [ ] **Step 1: スタイルを作成**
+
+`src/styles/components/common/connectionstatus.module.scss`:
+
+```scss
+.banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    padding: 6px 12px;
+    text-align: center;
+    font-size: 13px;
+    color: #fff;
+    background: rgba(180, 90, 90, 0.92);
+}
+```
+
+- [ ] **Step 2: コンポーネントを作成**
+
+`src/components/common/ConnectionStatus.tsx`(`reconnecting`/`disconnected` のみ表示。UI の網羅テストは書かない方針):
+
+```tsx
+import styles from '../../styles/components/common/connectionstatus.module.scss';
+import type { ConnectionStatus as Status } from '../../lib/stomp/types';
+
+export default function ConnectionStatus({ status }: { status: Status }) {
+    if (status !== 'reconnecting' && status !== 'disconnected') {
+        return null;
+    }
+    return (
+        <div className={styles.banner} role="status">
+            {status === 'reconnecting' ? '再接続中…' : '接続が切れました'}
+        </div>
+    );
+}
+```
+
+- [ ] **Step 3: ビルド確認**
+
+Run: `npm run build`
+Expected: 成功。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/common/ConnectionStatus.tsx src/styles/components/common/connectionstatus.module.scss
+git commit -m "接続状態インジケータConnectionStatusを追加"
+```
+
+---
+
+## 移行タスク共通レシピ(Task 3〜7)
+
+各ゲームページで以下を機械的に行う(ゲーム固有の差異は各タスクに明記):
+
+1. import 変更: `import SockJsClient from 'react-stomp';` を削除し、
+   `import { useGameSocket } from '../../lib/stomp/useGameSocket';`
+   `import ConnectionStatus from '../../components/common/ConnectionStatus';` を追加
+2. ファイル冒頭の `const disconnect = () => { console.log('接続が切れました'); };` を削除
+3. `const [clientObj, setClientObj] = useState(null);` を削除、`const [isConnected, setIsConnected] = useState(false);` があれば削除
+4. コンポーネント本体の適切な位置(roomId 取得直後)に:
+   ```tsx
+   const { connected, status, send } = useGameSocket({
+       topic: `<そのゲームの topic>`,
+       onMessage: <そのゲームの受信ハンドラ関数>,
+       enabled: !!roomId,
+   });
+   ```
+5. 送信ラッパー(`conect`/`coneect`)内の `clientObj.sendMessage(url, JSON.stringify(x))` を `send(url, x)` に変更(**JSON.stringify を外す**)。timebomb は直接 `clientObj.sendMessage(...)` する箇所も同様に `send(...)` へ
+6. `<SockJsClient ... />` の JSX を削除し、代わりに `<ConnectionStatus status={status} />` を置く
+7. `disabled={!isConnected}` を `disabled={!connected}` に置換(decrypt は該当なし)
+8. 受信ハンドラ本体(status switch)は**変更しない**
+
+移行後の検証(各タスク共通):
+- `npm run build` 成功、`npm run lint` error 0
+- `npm run dev` 起動 → 本番 Heroku 接続で該当ゲームのルームに入室でき、送受信の往復(名前入力→入室→他タブに反映)が成立
+- 送信で二重エンコードが起きていないこと(入室・アクションがバックエンドに正しく届く)を確認
+
+---
+
+### Task 3: hideout を useGameSocket に移行(パターン確立)
+
+**Files:**
+- Modify: `src/pages/hideout/[roomId].tsx`
+
+**Interfaces:**
+- Consumes: `useGameSocket`(Task 1)、`ConnectionStatus`(Task 2)
+- Produces: なし(ページ内で完結)
+
+固有情報:
+- topic: `` `/topic/${roomId}` ``
+- 受信ハンドラ: `getMessage`(`onMessage: getMessage`)
+- 送信ラッパー: `const conect = (url, soketInfo) => { try { clientObj.sendMessage(url, JSON.stringify(soketInfo)); } catch(e) {...} }` → 中身を `send(url, soketInfo)` に
+- `isConnected` あり(`disabled={!isConnected}` 2箇所を `!connected` に)
+
+- [ ] **Step 1: 共通レシピ(上記)を hideout に適用**
+
+`src/pages/hideout/[roomId].tsx` を編集:
+- import 差し替え(SockJsClient 削除 → useGameSocket + ConnectionStatus 追加)
+- `disconnect` 関数削除
+- `clientObj` / `isConnected` の useState 削除
+- roomId 取得直後にフック追加:
+  ```tsx
+  const { connected, status, send } = useGameSocket({
+      topic: `/topic/${roomId}`,
+      onMessage: getMessage,
+      enabled: !!roomId,
+  });
+  ```
+- `conect` の中身を差し替え:
+  ```tsx
+  const conect = (url: string, soketInfo: SocketInfo) => {
+      try {
+          send(url, soketInfo);
+      } catch (e) {
+          setMessageList(messageList.concat('通信エラー。再度試してください'));
+      }
+  };
+  ```
+- `<SockJsClient .../>` を削除し `<ConnectionStatus status={status} />` を設置
+- `disabled={!isConnected}` → `disabled={!connected}`(2箇所)
+
+注意: `getMessage` はフックより後ろで定義されている場合、関数宣言(hoisting される `function` ではなく `const`)だと参照エラーになる。hideout の `getMessage` は `const getMessage = ...` のため、**フック呼び出しを `getMessage` 定義より後ろに置く**か、`onMessage: (msg) => getMessage(msg)` の形にしてクロージャで遅延参照する。後者(ラップ)を採用する:
+```tsx
+const { connected, status, send } = useGameSocket({
+    topic: `/topic/${roomId}`,
+    onMessage: (msg) => getMessage(msg),
+    enabled: !!roomId,
+});
+```
+
+- [ ] **Step 2: ビルド・lint**
+
+Run: `npm run build && npm run lint`
+Expected: build 成功、lint error 0。
+
+- [ ] **Step 3: 本番接続で動作確認**
+
+Run: `npm run dev` → ブラウザで `http://localhost:3000/hideout/<createroomで取得したid>` に2タブ入室 → 送受信往復・接続インジケータ(dev再起動で「再接続中…」→自動復帰)を確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/hideout/\[roomId\].tsx
+git commit -m "hideoutをuseGameSocketに移行"
+```
+
+---
+
+### Task 4: decrypt を useGameSocket に移行(isConnected 未使用ケース)
+
+**Files:**
+- Modify: `src/pages/decrypt/[roomId].tsx`
+
+**Interfaces:**
+- Consumes: `useGameSocket`、`ConnectionStatus`
+
+固有情報:
+- topic: `` `/topic/${roomId}` ``
+- 受信ハンドラ: `getMessage`(`onMessage: (msg) => getMessage(msg)`)
+- 送信ラッパー: `const conect = (url, soketInfo) => { try { clientObj.sendMessage(url, JSON.stringify(soketInfo)); } catch {...} }` → `send(url, soketInfo)`
+- **`isConnected` / `onConnect` は元々無い**。`connected` は使わない(返り値から取らなくてよいが、`status` は ConnectionStatus 用に取る)
+
+- [ ] **Step 1: 共通レシピを decrypt に適用**
+
+- import 差し替え、`disconnect` 削除、`clientObj` useState 削除
+- フック追加(`connected` は未使用なので `status` と `send` のみ利用):
+  ```tsx
+  const { status, send } = useGameSocket({
+      topic: `/topic/${roomId}`,
+      onMessage: (msg) => getMessage(msg),
+      enabled: !!roomId,
+  });
+  ```
+  (受信関数は `getMessage`。既存の `onMessage={(msg)=>getMessage(msg)}` と同じ)
+- `conect` の中身を `send(url, soketInfo)` に
+- `<SockJsClient .../>` 削除 → `<ConnectionStatus status={status} />`
+- `disabled={!isConnected}` は decrypt には無い(確認して、もし入室ボタン等に無ければ何もしない)
+
+- [ ] **Step 2: ビルド・lint**
+
+Run: `npm run build && npm run lint`
+Expected: build 成功、lint error 0。
+
+- [ ] **Step 3: 本番接続で動作確認**
+
+Run: `npm run dev` → `http://localhost:3000/decrypt/<createroom/decrypt で取得したid>` に入室 → 送受信往復を確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/decrypt/\[roomId\].tsx
+git commit -m "decryptをuseGameSocketに移行"
+```
+
+---
+
+### Task 5: werewolf を useGameSocket に移行
+
+**Files:**
+- Modify: `src/pages/werewolf/[roomId].tsx`
+
+**Interfaces:**
+- Consumes: `useGameSocket`、`ConnectionStatus`
+
+固有情報:
+- topic: `` `/topic/${roomId}` ``
+- 受信ハンドラ: `getMessage`(`onMessage: (msg) => getMessage(msg)`)
+- 送信ラッパー: `const conect = (url, soketInfo) => { try { clientObj.sendMessage(url, JSON.stringify(soketInfo)); } catch {...} }` → `send(url, soketInfo)`
+- `isConnected` あり(`disabled={!isConnected}` 2箇所 → `!connected`)
+
+- [ ] **Step 1: 共通レシピを werewolf に適用**(hideout と同型。topic は `/topic/${roomId}`)
+
+- import 差し替え、`disconnect` 削除、`clientObj`/`isConnected` useState 削除
+- フック追加:
+  ```tsx
+  const { connected, status, send } = useGameSocket({
+      topic: `/topic/${roomId}`,
+      onMessage: (msg) => getMessage(msg),
+      enabled: !!roomId,
+  });
+  ```
+- `conect` の中身を `send(url, soketInfo)` に
+- `<SockJsClient .../>` 削除 → `<ConnectionStatus status={status} />`
+- `disabled={!isConnected}` → `disabled={!connected}`(2箇所)
+
+- [ ] **Step 2: ビルド・lint**
+
+Run: `npm run build && npm run lint`
+Expected: build 成功、lint error 0。
+
+- [ ] **Step 3: 本番接続で動作確認**
+
+Run: `npm run dev` → `http://localhost:3000/werewolf/<id>` に入室 → 送受信往復を確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/werewolf/\[roomId\].tsx
+git commit -m "werewolfをuseGameSocketに移行"
+```
+
+---
+
+### Task 6: fakeartist を useGameSocket に移行
+
+**Files:**
+- Modify: `src/pages/fakeartist/[roomId].tsx`
+
+**Interfaces:**
+- Consumes: `useGameSocket`、`ConnectionStatus`
+
+固有情報:
+- topic: `` `/topic/${roomId}` ``
+- 受信ハンドラ: `getMessage`(`onMessage: (msg) => getMessage(msg)`)
+- 送信ラッパー: `const conect = (url, soketInfo) => { try { clientObj.sendMessage(url, JSON.stringify(soketInfo)); } catch {...} }` → `send(url, soketInfo)`
+- `isConnected` あり(`disabled={!isConnected}` 2箇所 → `!connected`)
+
+- [ ] **Step 1: 共通レシピを fakeartist に適用**(werewolf と同型。topic は `/topic/${roomId}`)
+
+- import 差し替え、`disconnect` 削除、`clientObj`/`isConnected` useState 削除
+- フック追加:
+  ```tsx
+  const { connected, status, send } = useGameSocket({
+      topic: `/topic/${roomId}`,
+      onMessage: (msg) => getMessage(msg),
+      enabled: !!roomId,
+  });
+  ```
+- `conect` の中身を `send(url, soketInfo)` に
+- `<SockJsClient .../>` 削除 → `<ConnectionStatus status={status} />`
+- `disabled={!isConnected}` → `disabled={!connected}`(2箇所)
+
+- [ ] **Step 2: ビルド・lint**
+
+Run: `npm run build && npm run lint`
+Expected: build 成功、lint error 0。
+
+- [ ] **Step 3: 本番接続で動作確認**
+
+Run: `npm run dev` → `http://localhost:3000/fakeartist/<id>` に入室 → 送受信往復 + カラーピッカーで描画 → 描画が同期することを確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/fakeartist/\[roomId\].tsx
+git commit -m "fakeartistをuseGameSocketに移行"
+```
+
+---
+
+### Task 7: timebomb を useGameSocket に移行(別トピック・送信4箇所)
+
+**Files:**
+- Modify: `src/pages/timebomb/[roomId].tsx`
+
+**Interfaces:**
+- Consumes: `useGameSocket`、`ConnectionStatus`
+
+固有情報(**他ゲームと異なる点に注意**):
+- topic: **`` `/topic/${roomId}/timebomb` ``**(timebomb だけ末尾に `/timebomb`)
+- 受信ハンドラ: `receve`(`onMessage: (msg) => receve(msg)`)
+- 送信ラッパー: `const coneect = (url, msg) => { try { clientObj.sendMessage(url, JSON.stringify(msg)); } catch(e) {...} }`(名前が `coneect`)→ 中身を `send(url, msg)` に
+- **送信の直接呼び出しが3箇所ある**: `limittimeDone`(`clientObj.sendMessage(url, JSON.stringify(info))`)、`changeLimitTme`、`changeSecretFlg`。これらもすべて `send(url, info)` に置換(JSON.stringify を外す)
+- `isConnected` あり(`disabled={!isConnected}` 2箇所 → `!connected`)
+
+- [ ] **Step 1: 共通レシピを timebomb に適用(topic と送信箇所に注意)**
+
+- import 差し替え、`disconnect` 削除、`clientObj`/`isConnected` useState 削除
+- フック追加(**topic の末尾 `/timebomb` を忘れない**):
+  ```tsx
+  const { connected, status, send } = useGameSocket({
+      topic: `/topic/${roomId}/timebomb`,
+      onMessage: (msg) => receve(msg),
+      enabled: !!roomId,
+  });
+  ```
+- `coneect` の中身を `send(url, msg)` に
+- `limittimeDone` / `changeLimitTme` / `changeSecretFlg` 内の `clientObj.sendMessage(url, JSON.stringify(info))` を `send(url, info)` に(計3箇所。`limittimeDone` は元々 try/catch 付き、他2つは素の呼び出し — 呼び出し形だけ置換し try/catch の有無は現状維持)
+- `<SockJsClient .../>` 削除 → `<ConnectionStatus status={status} />`
+- `disabled={!isConnected}` → `disabled={!connected}`(2箇所)
+
+- [ ] **Step 2: ビルド・lint**
+
+Run: `npm run build && npm run lint`
+Expected: build 成功、lint error 0。
+
+- [ ] **Step 3: 本番接続で動作確認(topic の別扱いを重点確認)**
+
+Run: `npm run dev` → `http://localhost:3000/timebomb/<createroomで取得したid>` に2タブ入室 → GAME START → カード公開 → 制限時間ラジオ・SECRET MODE の切替が**他タブに同期**すること(= `/topic/{roomId}/timebomb` の購読と4送信経路がすべて正しい)を確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/timebomb/\[roomId\].tsx
+git commit -m "timebombをuseGameSocketに移行"
+```
+
+---
+
+### Task 8: react-stomp 削除と Stage 2 完了検証
+
+**Files:**
+- Modify: `package.json` / `package-lock.json`
+- Modify: `docs/superpowers/plans/2026-07-04-stage2-communication.md`(検証記録)
+
+**Interfaces:**
+- Consumes: Task 1〜7 の全成果物
+
+- [ ] **Step 1: react-stomp への参照が残っていないことを確認**
+
+Run: `grep -rn "react-stomp\|SockJsClient\|clientObj\|sendMessage" src`
+Expected: **ヒット 0 件**(全ゲームが移行済み)。1件でも残っていたら該当を移行してから進む。
+
+- [ ] **Step 2: react-stomp を依存から削除**
+
+```bash
+npm uninstall react-stomp
+```
+
+- [ ] **Step 3: 全チェック**
+
+Run: `npm test && npm run lint && npm run build`
+Expected: テスト全 PASS(useGameSocket 8件 + next.config 3件)、lint error 0、build 成功。
+
+- [ ] **Step 4: 全5ゲーム最終確認(本番 Heroku 接続)**
+
+`npm run dev` で全5ゲームを再確認:
+- [ ] hideout: 入室・送受信往復
+- [ ] decrypt: 入室・送受信往復
+- [ ] werewolf: 入室・送受信往復
+- [ ] fakeartist: 入室・描画同期
+- [ ] timebomb: 入室・GAME START・設定同期(別トピック)
+- [ ] 再接続: dev サーバ再起動で「再接続中…」バナー表示 → 自動復帰
+- [ ] コンソールエラーが無いこと
+
+- [ ] **Step 5: 検証記録を記入して Commit**
+
+本ファイル末尾の「検証記録」に結果を記入:
+
+```bash
+git add package.json package-lock.json ../docs/superpowers/plans/2026-07-04-stage2-communication.md
+git commit -m "react-stompを削除しStage 2検証結果を記録"
+```
+
+---
+
+## 検証記録
+
+(Task 8 実行時に記入)
+
+- react-stomp 参照残存: なし / あれば列挙
+- useGameSocket テスト: X件 PASS
+- 全5ゲーム本番接続: 各ゲームの結果
+- 再接続インジケータ動作: 結果
+- 意図的な挙動差分: 接続インジケータの追加のみ(他はなし)
+- 次ステージへの申し送り(Stage 3: 受信ハンドラの reducer 化)

--- a/docs/superpowers/specs/2026-07-04-stage2-communication-design.md
+++ b/docs/superpowers/specs/2026-07-04-stage2-communication-design.md
@@ -1,0 +1,166 @@
+# Stage 2: 通信層の刷新 設計書
+
+作成日: 2026-07-04
+
+## 背景
+
+BoardGameFront の5ゲーム(timebomb / werewolf / hideout / decrypt / fakeartist)は、リアルタイム通信に **メンテナンス終了済みの `react-stomp`**(v5.1.0)を各ページで直接使用している。`react-stomp` は内部で旧 `stompjs`(v2)+ `sockjs-client` を抱えており、以下の負債がある。
+
+- ライブラリがメンテ終了。React 19 では peer deps 未宣言のため `legacy-peer-deps` で無理に共存させている(Stage 1 の申し送り)
+- 各ゲームページに `SockJsClient` が JSX として埋め込まれ、`clientObj` を `useState` で保持 → 命令的に `sendMessage` を呼ぶ、という React と噛み合わない構造
+- 切断時は `console.log('接続が切れました')` のみで、自動再接続もユーザーへの通知もない
+
+Stage 2 はこの通信層を **`@stomp/stompjs` v7 + `sockjs-client`** に置換し、型付きの共通フック `useGameSocket` に集約する。**バックエンド(Spring / SockJS+STOMP)は無変更**で互換を維持する。
+
+## 現状の通信パターン(全5ゲーム、調査済み)
+
+すべてのゲームが `react-stomp` の `SockJsClient` を同一パターンで使用:
+
+- `url` = `SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT`
+- `topics`: **timebomb のみ `/topic/{roomId}/timebomb`**、他4ゲームは `/topic/{roomId}`
+- `ref` で client を `clientObj` state に保持 → `clientObj.sendMessage(destination, JSON.stringify(payload))` で送信(**呼び出し側が JSON.stringify する**)
+- `onMessage(msg)` = ゲーム固有の受信ハンドラ(`receve` 等、status コードの巨大 switch)
+- `onConnect` → `setIsConnected(true)`(**decrypt のみ isConnected 未使用**)
+- `onDisconnect` → `disconnect`(console.log のみ)
+
+## ゴールと非ゴール
+
+### ゴール
+
+1. `react-stomp` を `@stomp/stompjs` v7 + `sockjs-client` に置換し、依存から削除する
+2. 型付き共通フック `useGameSocket` を1つ作り、5ゲームで共用する
+3. 自動再接続を導入し、切断/再接続を控えめな UI で通知する
+4. `useGameSocket` にユニットテストを整備する
+
+### 非ゴール
+
+- バックエンド(Java / SockJS エンドポイント `boardgame-endpoint`、STOMP トピック、宛先 `/app/*`)の変更 — 互換維持
+- 各ゲームの受信ハンドラ(`receve` の status switch)の reducer 化 — **Stage 3** で実施
+- ゲームのUI・進行・見た目の変更(接続インジケータの追加を除く)
+
+## 決定事項(ヒアリング結果)
+
+| 項目 | 決定 |
+|---|---|
+| 接続状態のUI | 控えめなインジケータを追加(再接続中/切断時のみ小さく表示、接続中は非表示) |
+| Stage 2 の範囲 | 通信層の差し替えに限定(受信ハンドラは無変更、reducer化はStage 3) |
+| ライブラリ | @stomp/stompjs v7 + sockjs-client(全体設計で承認済み) |
+| ブランチ | master から `refactor/stage2-communication` を新規作成 |
+| PR | Stage 2 全体で1本 |
+
+## アーキテクチャ
+
+### ディレクトリ構成(追加)
+
+```
+src/lib/stomp/
+  useGameSocket.ts   # @stomp/stompjs Client をラップした共通フック ★テスト対象
+  types.ts           # ConnectionStatus 等の型
+src/components/common/
+  ConnectionStatus.tsx   # 控えめな接続状態インジケータ
+```
+
+### `useGameSocket` フック
+
+```ts
+type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
+
+function useGameSocket(opts: {
+  topic: string;                    // 呼び出し側が組み立てる(timebomb: `/topic/${roomId}/timebomb`、他: `/topic/${roomId}`)
+  onMessage: (msg: any) => void;    // ゲーム固有の受信ハンドラ(既存の receve をそのまま渡す)
+  enabled: boolean;                 // roomId 未確定(router未準備)の間は接続しない
+}): {
+  status: ConnectionStatus;
+  connected: boolean;               // status === 'connected'
+  send: (destination: string, payload: unknown) => void;
+};
+```
+
+内部仕様:
+- `new Client({ webSocketFactory: () => new SockJS(AP_HOST + ENDPOINT), reconnectDelay: 5000 })`
+- `enabled` が true になったら `activate()`、アンマウント/`enabled` false で `deactivate()`
+- 接続確立(`onConnect`)後に `topic` を購読。受信 body を `JSON.parse`(失敗時は生文字列)して `onMessage` に渡す(react-stomp の `_processMessage` と同じ挙動)
+- `send(dest, payload)`: `client.publish({ destination: dest, body: JSON.stringify(payload) })`。**未接続時は例外を投げる**(現状の `sendMessage` と同じ挙動 → 既存の try/catch がそのまま機能する)
+- 再接続時に既存 subscription を破棄してから再購読(重複購読防止)
+- `status` を state として公開。`onWebSocketClose`/`activate` 等のライフサイクルで `connecting`→`connected`→`reconnecting`→... を反映
+
+### 接続インジケータ `ConnectionStatus`
+
+- props: `{ status: ConnectionStatus }`
+- `reconnecting` / `disconnected` のときだけ画面端に小さなバナー(例: 「再接続中…」)を表示。`connected` / `connecting`(初回)では何も表示しない
+- 各ゲームページに1要素差し込むだけ
+
+### 各ゲームページの変更(差し替えのみ)
+
+Before:
+```tsx
+const [clientObj, setClientObj] = useState(null);
+const [isConnected, setIsConnected] = useState(false);
+...
+clientObj.sendMessage(url, JSON.stringify(msg));
+...
+<SockJsClient url={...} topics={['/topic/'+roomId]} ref={c=>setClientObj(c)} onMessage={receve} onConnect={()=>setIsConnected(true)} onDisconnect={disconnect} />
+```
+
+After:
+```tsx
+const { connected, status, send } = useGameSocket({
+  topic: `/topic/${roomId}`,          // timebomb だけ `/topic/${roomId}/timebomb`
+  onMessage: receve,                   // 受信ハンドラは無変更
+  enabled: !!roomId,
+});
+...
+send(url, msg);                        // JSON.stringify はフック内部で行う(呼び出し側からは外す)
+...
+<ConnectionStatus status={status} />
+```
+
+- **受信ロジック(`receve` の status switch)は一切変更しない**
+- `isConnected` → `connected` に置換。decrypt は元々未使用なので `connected` を無視
+- **送信呼び出しから `JSON.stringify()` を外す**(フックが内部で行うため。二重エンコード防止 — 移行時の必須チェック項目)
+- 各ゲームの `disconnect`(console.log 関数)は不要になるため削除
+
+## 移行順
+
+共通フック・インジケータ・テストを先に作り、その後ゲームを1つずつ移行(各移行後に本番接続で動作確認):
+
+1. **hideout**(素直な `/topic/{roomId}`、送信箇所少)= パターン確立
+2. **decrypt**(`isConnected` 未使用の特殊ケース)
+3. **werewolf**
+4. **fakeartist**
+5. **timebomb**(唯一 `/topic/{roomId}/timebomb` の別トピック)
+
+全5ゲーム移行後に **`react-stomp` を依存から削除**。
+
+## テスト戦略
+
+- **`useGameSocket` のユニットテスト**(主戦場): `@stomp/stompjs` の `Client` をモックし、
+  - `enabled` false の間は接続せず、true で `activate()` される
+  - 接続時に指定 `topic` を購読する
+  - `send()` が `publish({ destination, body: JSON.stringify(payload) })` を呼ぶ / 未接続時は例外を投げる
+  - 受信 body を `JSON.parse` して `onMessage` に渡す(不正JSONは生文字列で渡す)
+  - status 遷移(connecting→connected→reconnecting)
+  - 再接続時に重複購読しない(古い subscription を破棄)
+- `ConnectionStatus`(UI)の網羅テストは書かない(方針通り)
+
+## 検証
+
+- 各ゲーム移行後、本番 Heroku 接続で「入室 → ゲーム進行」を確認(Stage 1 と同じ手法。ブラウザ複数タブ)
+- **再接続**: dev サーバ再起動やネットワーク断で `reconnecting` バナーが出て自動復帰することを確認
+- 送受信の往復(送信 → バックエンドが `/topic` にブロードキャスト → UI 反映)が全ゲームで成立することを確認
+
+## リスク
+
+| リスク | 対策 |
+|---|---|
+| 二重 stringify / stringify 外し漏れ | 移行チェックリスト化。1ゲームずつ本番で送受信往復を確認 |
+| 接続前 subscribe のタイミング | フック内で `onConnect` 後に購読。ユニットテストで担保 |
+| timebomb の別トピック取り違え | timebomb を最後に回し、topic 文字列を明示検証 |
+| 再接続時の重複購読 | アンマウント/再接続時に既存 subscription を破棄。ユニットテストで担保 |
+| @stomp/stompjs と sockjs-client の peer 整合 | Stage 1 の `.npmrc`(legacy-peer-deps)下で導入。react-stomp 削除後に peer 警告が減る想定 |
+
+## 完了条件
+
+- `react-stomp` が依存から削除され、全5ゲームが `useGameSocket` 経由で本番バックエンドと送受信できる
+- `useGameSocket` のユニットテストが通る
+- 切断時に自動再接続し、`reconnecting` インジケータが表示される

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,6 @@
         "react-color": "^2.19.3",
         "react-dom": "^19.2.7",
         "react-share": "^5.3.0",
-        "react-stomp": "^5.1.0",
         "sass": "^1.101.0",
         "sockjs-client": "^1.6.1"
       },
@@ -4251,16 +4250,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
-      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.2.0"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4465,16 +4454,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4913,38 +4892,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "optional": true,
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "optional": true,
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "optional": true,
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "node_modules/esbuild": {
@@ -5849,21 +5796,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "optional": true,
-      "dependencies": {
-        "type": "^2.0.0"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
-      "optional": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6243,26 +6175,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/has-bigints": {
@@ -6914,12 +6826,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "optional": true
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -7319,6 +7225,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7368,16 +7275,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-    },
-    "node_modules/net": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
-      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
     },
     "node_modules/next": {
       "version": "15.5.20",
@@ -7431,12 +7328,6 @@
         }
       }
     },
-    "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "optional": true
-    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -7471,17 +7362,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nwsapi": {
@@ -7953,17 +7833,6 @@
       },
       "peerDependencies": {
         "react": "^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-stomp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-stomp/-/react-stomp-5.1.0.tgz",
-      "integrity": "sha512-LYgNpKITRL4BDDoVd4llC0t0CKsIipiSRV5SkDW7yI5wxlbuHcEi512dubNGtNLaaujNvgKAuFK9r8w7tecS4Q==",
-      "dependencies": {
-        "handlebars": "^4.7.6",
-        "net": "^1.0.2",
-        "sockjs-client": "^1.5.0",
-        "stompjs": "^2.3.3"
       }
     },
     "node_modules/reactcss": {
@@ -8549,14 +8418,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8591,14 +8452,6 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stompjs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/stompjs/-/stompjs-2.3.3.tgz",
-      "integrity": "sha1-NBeKx7uO4pTMXVVK2LUPf1RZ/Y4=",
-      "optionalDependencies": {
-        "websocket": "^1.0.33"
-      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8987,12 +8840,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "optional": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9084,15 +8931,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "optional": true,
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -9105,18 +8943,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
-      "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -9201,16 +9027,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
-      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.2.0"
       }
     },
     "node_modules/vite": {
@@ -9512,23 +9328,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/websocket": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
-      "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
-      "optional": true,
-      "dependencies": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
@@ -9722,11 +9521,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -9765,15 +9559,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.32"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -12061,15 +11846,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "bufferutil": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
-      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
-      "optional": true,
-      "requires": {
-        "node-gyp-build": "^4.2.0"
-      }
-    },
     "cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -12205,16 +11981,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -12534,38 +12300,6 @@
         "is-callable": "^1.2.7",
         "is-date-object": "^1.1.0",
         "is-symbol": "^1.1.1"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "optional": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "optional": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "optional": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "esbuild": {
@@ -13161,23 +12895,6 @@
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true
     },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "optional": true,
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
-          "optional": true
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -13428,18 +13145,6 @@
         "kind-of": "^6.0.2",
         "section-matter": "^1.0.0",
         "strip-bom-string": "^1.0.0"
-      }
-    },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
       }
     },
     "has-bigints": {
@@ -13848,12 +13553,6 @@
         "which-typed-array": "^1.1.16"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "optional": true
-    },
     "is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -14148,7 +13847,8 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -14172,16 +13872,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-    },
-    "net": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
-      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
-    },
     "next": {
       "version": "15.5.20",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
@@ -14202,12 +13892,6 @@
         "sharp": "^0.34.3",
         "styled-jsx": "5.1.6"
       }
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "optional": true
     },
     "node-addon-api": {
       "version": "7.1.1",
@@ -14234,12 +13918,6 @@
           "dev": true
         }
       }
-    },
-    "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "optional": true
     },
     "nwsapi": {
       "version": "2.2.24",
@@ -14540,17 +14218,6 @@
       "requires": {
         "classnames": "^2.3.2",
         "jsonp": "^0.2.1"
-      }
-    },
-    "react-stomp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-stomp/-/react-stomp-5.1.0.tgz",
-      "integrity": "sha512-LYgNpKITRL4BDDoVd4llC0t0CKsIipiSRV5SkDW7yI5wxlbuHcEi512dubNGtNLaaujNvgKAuFK9r8w7tecS4Q==",
-      "requires": {
-        "handlebars": "^4.7.6",
-        "net": "^1.0.2",
-        "sockjs-client": "^1.5.0",
-        "stompjs": "^2.3.3"
       }
     },
     "reactcss": {
@@ -14941,11 +14608,6 @@
         }
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
     "source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -14973,14 +14635,6 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
-    },
-    "stompjs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/stompjs/-/stompjs-2.3.3.tgz",
-      "integrity": "sha1-NBeKx7uO4pTMXVVK2LUPf1RZ/Y4=",
-      "requires": {
-        "websocket": "^1.0.33"
-      }
     },
     "stop-iteration-iterator": {
       "version": "1.1.0",
@@ -15240,12 +14894,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "optional": true
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -15308,26 +14956,11 @@
         "reflect.getprototypeof": "^1.0.10"
       }
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "optional": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
-      "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
-      "optional": true
     },
     "unbox-primitive": {
       "version": "1.1.0",
@@ -15394,15 +15027,6 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "utf-8-validate": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
-      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
-      "optional": true,
-      "requires": {
-        "node-gyp-build": "^4.2.0"
       }
     },
     "vite": {
@@ -15538,20 +15162,6 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true
     },
-    "websocket": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
-      "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
-      "optional": true,
-      "requires": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      }
-    },
     "websocket-driver": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
@@ -15678,11 +15288,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
     "ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -15700,12 +15305,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-      "optional": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "learn-starter",
       "version": "0.1.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.3.0",
         "@tsparticles/engine": "^3.9.1",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.9.1",
@@ -19,19 +20,191 @@
         "react-dom": "^19.2.7",
         "react-share": "^5.3.0",
         "react-stomp": "^5.1.0",
-        "sass": "^1.101.0"
+        "sass": "^1.101.0",
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.20.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/sockjs-client": "^1.5.4",
         "eslint": "^9.39.4",
         "eslint-config-next": "^15.5.20",
         "eslint-config-prettier": "^10.1.8",
+        "jsdom": "^25.0.1",
         "prettier": "^3.9.4",
         "typescript": "^5.9.3",
         "vitest": "^3.2.6"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2182,6 +2355,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2196,6 +2375,64 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@tsparticles/basic": {
       "version": "3.9.1",
@@ -2716,6 +2953,13 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2784,6 +3028,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.62.1",
@@ -3674,6 +3925,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3689,6 +3950,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/argparse": {
@@ -3895,6 +4179,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4113,6 +4404,19 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4133,6 +4437,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4157,6 +4482,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4225,6 +4564,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4278,6 +4624,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4301,6 +4667,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4322,6 +4695,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -5445,14 +5831,12 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-      "dependencies": {
-        "original": "^1.0.0"
-      },
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.12.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -5528,9 +5912,10 @@
       }
     },
     "node_modules/faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "websocket-driver": ">=0.5.1"
       },
@@ -5633,6 +6018,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -5947,10 +6349,115 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-parser-js": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
-      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6301,6 +6808,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6501,6 +7015,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6520,11 +7075,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "node_modules/json3": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
-      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -6665,6 +7215,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6710,6 +7277,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -6894,6 +7484,13 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7032,14 +7629,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dependencies": {
-        "url-parse": "^1.4.3"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -7100,6 +7689,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -7228,6 +7830,28 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7252,7 +7876,8 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7409,7 +8034,8 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
@@ -7509,6 +8135,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7569,7 +8202,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7606,6 +8240,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sass": {
       "version": "1.101.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
@@ -7624,6 +8265,19 @@
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7869,16 +8523,22 @@
       "license": "ISC"
     },
     "node_modules/sockjs-client": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
-      "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "^0.11.3",
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
         "inherits": "^2.0.4",
-        "json3": "^3.3.3",
-        "url-parse": "^1.5.1"
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
       }
     },
     "node_modules/sockjs-client/node_modules/debug": {
@@ -8154,6 +8814,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8236,6 +8903,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8246,6 +8933,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8481,9 +9194,10 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -8775,6 +9489,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/websocket": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
@@ -8793,9 +9530,10 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -8809,8 +9547,47 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -8950,6 +9727,45 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
@@ -8974,6 +9790,76 @@
     }
   },
   "dependencies": {
+    "@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "requires": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true
+    },
+    "@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true
+    },
+    "@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true
+    },
+    "@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "requires": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      }
+    },
+    "@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true
+    },
+    "@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true
+    },
     "@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -9985,6 +10871,11 @@
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true
     },
+    "@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ=="
+    },
     "@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -9998,6 +10889,42 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
           "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
+      }
+    },
+    "@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+          "dev": true,
+          "requires": {
+            "dequal": "^2.0.3"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@tsparticles/basic": {
@@ -10343,6 +11270,12 @@
         }
       }
     },
+    "@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -10399,6 +11332,12 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true
+    },
+    "@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
       "dev": true
     },
     "@typescript-eslint/project-service": {
@@ -10901,6 +11840,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -10912,6 +11857,18 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -11050,6 +12007,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "available-typed-arrays": {
@@ -11193,6 +12156,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -11208,6 +12180,24 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "dependencies": {
+        "rrweb-cssom": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+          "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+          "dev": true
+        }
       }
     },
     "csstype": {
@@ -11231,6 +12221,16 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "requires": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      }
     },
     "data-view-buffer": {
       "version": "1.0.2",
@@ -11280,6 +12280,12 @@
         }
       }
     },
+    "decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
     "deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -11314,6 +12320,18 @@
         "object-keys": "^1.1.1"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -11328,6 +12346,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -11344,6 +12368,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true
     },
     "es-abstract": {
@@ -12121,12 +13151,9 @@
       "dev": true
     },
     "eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-      "requires": {
-        "original": "^1.0.0"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
     },
     "expect-type": {
       "version": "1.4.0",
@@ -12192,9 +13219,9 @@
       }
     },
     "faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
@@ -12256,6 +13283,19 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.2.7"
+      }
+    },
+    "form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       }
     },
     "fsevents": {
@@ -12450,10 +13490,82 @@
         "function-bind": "^1.1.2"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^3.1.1"
+      }
+    },
     "http-parser-js": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
-      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
+    },
+    "http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
     },
     "ignore": {
       "version": "5.3.2",
@@ -12673,6 +13785,12 @@
         "has-tostringtag": "^1.0.2"
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12801,6 +13919,35 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "requires": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      }
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -12818,11 +13965,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json3": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
-      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "json5": {
       "version": "1.0.2",
@@ -12931,6 +14073,18 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -12965,6 +14119,21 @@
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
@@ -13072,6 +14241,12 @@
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
       "optional": true
     },
+    "nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -13164,14 +14339,6 @@
         "word-wrap": "^1.2.5"
       }
     },
-    "original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "requires": {
-        "url-parse": "^1.4.3"
-      }
-    },
     "own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -13208,6 +14375,15 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "requires": {
+        "entities": "^6.0.0"
       }
     },
     "path-exists": {
@@ -13278,6 +14454,25 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
     },
     "prop-types": {
       "version": "15.8.1",
@@ -13404,7 +14599,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "2.0.0-next.7",
@@ -13473,6 +14668,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13521,6 +14722,12 @@
         "is-regex": "^1.2.1"
       }
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "sass": {
       "version": "1.101.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
@@ -13530,6 +14737,15 @@
         "chokidar": "^5.0.0",
         "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
+      }
+    },
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
       }
     },
     "scheduler": {
@@ -13704,16 +14920,15 @@
       "dev": true
     },
     "sockjs-client": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
-      "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
       "requires": {
-        "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "^0.11.3",
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
         "inherits": "^2.0.4",
-        "json3": "^3.3.3",
-        "url-parse": "^1.5.1"
+        "url-parse": "^1.5.10"
       },
       "dependencies": {
         "debug": {
@@ -13906,6 +15121,12 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -13959,6 +15180,21 @@
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true
     },
+    "tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "requires": {
+        "tldts-core": "^6.1.86"
+      }
+    },
+    "tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13966,6 +15202,24 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "requires": {
+        "tldts": "^6.1.32"
+      }
+    },
+    "tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.3.1"
       }
     },
     "ts-api-utils": {
@@ -14134,9 +15388,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -14269,6 +15523,21 @@
         }
       }
     },
+    "w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^5.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true
+    },
     "websocket": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
@@ -14284,9 +15553,9 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "requires": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -14297,6 +15566,31 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "requires": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -14388,6 +15682,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "yaeti": {
       "version": "0.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.3.0",
     "@tsparticles/engine": "^3.9.1",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.9.1",
@@ -24,16 +25,21 @@
     "react-dom": "^19.2.7",
     "react-share": "^5.3.0",
     "react-stomp": "^5.1.0",
-    "sass": "^1.101.0"
+    "sass": "^1.101.0",
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.20.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/sockjs-client": "^1.5.4",
     "eslint": "^9.39.4",
     "eslint-config-next": "^15.5.20",
     "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^25.0.1",
     "prettier": "^3.9.4",
     "typescript": "^5.9.3",
     "vitest": "^3.2.6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,6 @@
     "react-color": "^2.19.3",
     "react-dom": "^19.2.7",
     "react-share": "^5.3.0",
-    "react-stomp": "^5.1.0",
     "sass": "^1.101.0",
     "sockjs-client": "^1.6.1"
   },

--- a/frontend/src/components/common/ConnectionStatus.tsx
+++ b/frontend/src/components/common/ConnectionStatus.tsx
@@ -1,0 +1,13 @@
+import styles from '../../styles/components/common/connectionstatus.module.scss';
+import type { ConnectionStatus as Status } from '../../lib/stomp/types';
+
+export default function ConnectionStatus({ status }: { status: Status }) {
+    if (status !== 'reconnecting' && status !== 'disconnected') {
+        return null;
+    }
+    return (
+        <div className={styles.banner} role="status">
+            {status === 'reconnecting' ? '再接続中…' : '接続が切れました'}
+        </div>
+    );
+}

--- a/frontend/src/lib/stomp/types.ts
+++ b/frontend/src/lib/stomp/types.ts
@@ -1,0 +1,11 @@
+export type ConnectionStatus =
+    | 'connecting'
+    | 'connected'
+    | 'reconnecting'
+    | 'disconnected';
+
+export type GameSocket = {
+    status: ConnectionStatus;
+    connected: boolean;
+    send: (destination: string, payload: unknown) => void;
+};

--- a/frontend/src/lib/stomp/useGameSocket.test.ts
+++ b/frontend/src/lib/stomp/useGameSocket.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// @stomp/stompjs の Client をモック(生成された各インスタンスを instances に記録)
+vi.mock('@stomp/stompjs', () => {
+    class MockClient {
+        config: any;
+        connected = false;
+        activate = vi.fn();
+        deactivate = vi.fn(() => Promise.resolve());
+        subscribe = vi.fn(() => ({ unsubscribe: vi.fn() }));
+        publish = vi.fn();
+        static instances: any[] = [];
+        constructor(config: any) {
+            this.config = config;
+            MockClient.instances.push(this);
+        }
+        // テスト用: 接続確立を模擬
+        _open() {
+            this.connected = true;
+            this.config.onConnect();
+        }
+        // テスト用: 切断を模擬
+        _close() {
+            this.connected = false;
+            this.config.onWebSocketClose?.();
+        }
+    }
+    return { Client: MockClient };
+});
+
+// sockjs-client は webSocketFactory 内でのみ参照。実接続させないためモック
+vi.mock('sockjs-client', () => ({ default: vi.fn() }));
+
+import { Client } from '@stomp/stompjs';
+import { useGameSocket } from './useGameSocket';
+
+const MockClient = Client as unknown as { instances: any[] };
+
+beforeEach(() => {
+    MockClient.instances.length = 0;
+});
+
+describe('useGameSocket', () => {
+    it('enabled=false の間は Client を生成しない', () => {
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: false })
+        );
+        expect(MockClient.instances.length).toBe(0);
+    });
+
+    it('enabled=true で activate し status は connecting', () => {
+        const { result } = renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        expect(MockClient.instances.length).toBe(1);
+        expect(MockClient.instances[0].activate).toHaveBeenCalled();
+        expect(result.current.status).toBe('connecting');
+        expect(result.current.connected).toBe(false);
+    });
+
+    it('接続確立で status=connected になり、指定 topic を購読する', () => {
+        const { result } = renderHook(() =>
+            useGameSocket({ topic: '/topic/room1', onMessage: () => {}, enabled: true })
+        );
+        act(() => MockClient.instances[0]._open());
+        expect(result.current.status).toBe('connected');
+        expect(result.current.connected).toBe(true);
+        expect(MockClient.instances[0].subscribe).toHaveBeenCalledWith(
+            '/topic/room1',
+            expect.any(Function)
+        );
+    });
+
+    it('受信 body を JSON.parse して onMessage に渡す', () => {
+        const onMessage = vi.fn();
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage, enabled: true })
+        );
+        act(() => MockClient.instances[0]._open());
+        const handler = MockClient.instances[0].subscribe.mock.calls[0][1];
+        act(() => handler({ body: '{"status":200,"turn":1}' }));
+        expect(onMessage).toHaveBeenCalledWith({ status: 200, turn: 1 });
+    });
+
+    it('不正JSONは生文字列で onMessage に渡す', () => {
+        const onMessage = vi.fn();
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage, enabled: true })
+        );
+        act(() => MockClient.instances[0]._open());
+        const handler = MockClient.instances[0].subscribe.mock.calls[0][1];
+        act(() => handler({ body: 'not-json' }));
+        expect(onMessage).toHaveBeenCalledWith('not-json');
+    });
+
+    it('send は接続時に publish(JSON.stringify)、未接続時は例外', () => {
+        const { result } = renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        // 未接続で送信 → 例外
+        expect(() => result.current.send('/app/roomin', { a: 1 })).toThrow();
+        // 接続後 → publish
+        act(() => MockClient.instances[0]._open());
+        act(() => result.current.send('/app/roomin', { a: 1 }));
+        expect(MockClient.instances[0].publish).toHaveBeenCalledWith({
+            destination: '/app/roomin',
+            body: '{"a":1}',
+        });
+    });
+
+    it('再接続(再度の onConnect)で古い subscription を解除してから再購読する', () => {
+        renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        const inst = MockClient.instances[0];
+        act(() => inst._open());
+        const firstSub = inst.subscribe.mock.results[0].value;
+        act(() => inst._close());
+        act(() => inst._open());
+        expect(firstSub.unsubscribe).toHaveBeenCalled();
+        expect(inst.subscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it('アンマウントで deactivate する', () => {
+        const { unmount } = renderHook(() =>
+            useGameSocket({ topic: '/topic/x', onMessage: () => {}, enabled: true })
+        );
+        const inst = MockClient.instances[0];
+        unmount();
+        expect(inst.deactivate).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/lib/stomp/useGameSocket.ts
+++ b/frontend/src/lib/stomp/useGameSocket.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Client, type IMessage, type StompSubscription } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+import { SystemConst } from '../../const/next.config';
+import type { ConnectionStatus, GameSocket } from './types';
+
+type UseGameSocketOptions = {
+    topic: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onMessage: (msg: any) => void;
+    enabled: boolean;
+};
+
+export function useGameSocket(opts: UseGameSocketOptions): GameSocket {
+    const { topic, onMessage, enabled } = opts;
+    const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+    const clientRef = useRef<Client | null>(null);
+    const subRef = useRef<StompSubscription | null>(null);
+
+    // onMessage の最新参照を保持(再接続を誘発しないため deps に入れない)
+    const onMessageRef = useRef(onMessage);
+    onMessageRef.current = onMessage;
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+        let hasConnected = false;
+
+        const client = new Client({
+            webSocketFactory: () =>
+                new SockJS(
+                    SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT
+                ),
+            reconnectDelay: 5000,
+            onConnect: () => {
+                hasConnected = true;
+                setStatus('connected');
+                if (subRef.current) {
+                    try {
+                        subRef.current.unsubscribe();
+                    } catch {
+                        // 破棄済みなら無視
+                    }
+                }
+                subRef.current = client.subscribe(topic, (message: IMessage) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    let parsed: any;
+                    try {
+                        parsed = JSON.parse(message.body);
+                    } catch {
+                        parsed = message.body;
+                    }
+                    onMessageRef.current(parsed);
+                });
+            },
+            onWebSocketClose: () => {
+                setStatus(hasConnected ? 'reconnecting' : 'connecting');
+            },
+        });
+
+        clientRef.current = client;
+        subRef.current = null;
+        setStatus('connecting');
+        client.activate();
+
+        return () => {
+            clientRef.current = null;
+            subRef.current = null;
+            client.deactivate();
+        };
+    }, [topic, enabled]);
+
+    const send = useCallback((destination: string, payload: unknown) => {
+        const client = clientRef.current;
+        if (!client || !client.connected) {
+            throw new Error('Send error: socket is disconnected');
+        }
+        client.publish({ destination, body: JSON.stringify(payload) });
+    }, []);
+
+    return { status, connected: status === 'connected', send };
+}

--- a/frontend/src/pages/decrypt/[roomId].tsx
+++ b/frontend/src/pages/decrypt/[roomId].tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { useRouter } from 'next/router';
-import SockJsClient from 'react-stomp';
 import { SystemConst } from '../../const/next.config';
 import Layout from '../../components/layout';
 import Head from 'next/head';
@@ -14,18 +13,20 @@ import Router from 'next/router';
 
 import Start from '../../components/timebomb/start';
 import TeamDataInfo from '../../components/decrypt/teamDataInfo';
-
-// 接続切れ
-const disconnect = () => {
-    console.log('接続が切れました');
-};
+import { useGameSocket } from '../../lib/stomp/useGameSocket';
+import ConnectionStatus from '../../components/common/ConnectionStatus';
 
 export default function DecryptRoom() {
     // roomId取得
     const router = useRouter();
     const { roomId } = router.query;
 
-    const [clientObj, setClientObj] = useState(null);
+    const { status, send } = useGameSocket({
+        topic: `/topic/${roomId}`,
+        onMessage: (msg) => getMessage(msg),
+        enabled: !!roomId,
+    });
+
     const [messageList, setMessageList] = useState([]);
     const [chatList, setChatList] = useState([]);
 
@@ -76,7 +77,7 @@ export default function DecryptRoom() {
             };
             conect(url, soketInfo);
         },
-        [clientObj, playerName]
+        [playerName]
     );
 
     // チャット
@@ -252,7 +253,7 @@ export default function DecryptRoom() {
 
     const conect = (url: string, soketInfo: SocketInfo) => {
         try {
-            clientObj.sendMessage(url, JSON.stringify(soketInfo));
+            send(url, soketInfo);
         } catch (e) {
             setMessageList(
                 messageList.concat('通信エラー。再度試してください')
@@ -450,17 +451,7 @@ export default function DecryptRoom() {
                 }
             })}
 
-            <SockJsClient
-                url={SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT}
-                topics={['/topic/' + roomId]}
-                ref={(client) => {
-                    setClientObj(client);
-                }}
-                onMessage={(msg) => {
-                    getMessage(msg);
-                }}
-                onDisconnect={disconnect}
-            />
+            <ConnectionStatus status={status} />
             <div className={styles.roominbtn}>
                 <p>
                     <label htmlFor="username">Name</label>

--- a/frontend/src/pages/fakeartist/[roomId].tsx
+++ b/frontend/src/pages/fakeartist/[roomId].tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { useRouter } from 'next/router';
-import SockJsClient from 'react-stomp';
 import { SystemConst } from '../../const/next.config';
 import Layout from '../../components/layout';
 import Head from 'next/head';
@@ -24,11 +23,8 @@ import RadioChips from '../../components/chips/radiochips';
 import HeaderInfo from '../../components/fakeartist/headInfo';
 import CountdownClock from '../../components/clock/countdownClock';
 import Socialbtn from '../../components/button/sosialbtn';
-
-// 接続切れ
-const disconnect = () => {
-    console.log('接続が切れました');
-};
+import { useGameSocket } from '../../lib/stomp/useGameSocket';
+import ConnectionStatus from '../../components/common/ConnectionStatus';
 
 // sleeep
 const sleep = (msec: number) => {
@@ -126,8 +122,12 @@ export default function FakeArtistRoom() {
     const router = useRouter();
     const { roomId } = router.query;
 
-    const [clientObj, setClientObj] = useState(null);
-    const [isConnected, setIsConnected] = useState(false);
+    const { connected, status, send } = useGameSocket({
+        topic: `/topic/${roomId}`,
+        onMessage: (msg) => getMessage(msg),
+        enabled: !!roomId,
+    });
+
     const [messageList, setMessageList] = useState([]);
     const [chatList, setChatList] = useState([]);
 
@@ -235,7 +235,7 @@ export default function FakeArtistRoom() {
             };
             conect(url, soketInfo);
         },
-        [clientObj, playerName]
+        [playerName]
     );
 
     // チャット
@@ -337,7 +337,7 @@ export default function FakeArtistRoom() {
 
     const conect = (url: string, soketInfo: SocketInfo) => {
         try {
-            clientObj.sendMessage(url, JSON.stringify(soketInfo));
+            send(url, soketInfo);
         } catch (e) {
             setMessageList(
                 messageList.concat('通信エラー。再度試してください')
@@ -842,26 +842,13 @@ export default function FakeArtistRoom() {
                 </div>
             )}
 
-            <SockJsClient
-                url={SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT}
-                topics={['/topic/' + roomId]}
-                ref={(client) => {
-                    setClientObj(client);
-                }}
-                onMessage={(msg) => {
-                    getMessage(msg);
-                }}
-                onConnect={() => {
-                    setIsConnected(true);
-                }}
-                onDisconnect={disconnect}
-            />
+            <ConnectionStatus status={status} />
             <div className={styles.roominbtn}>
                 <p>
                     <label htmlFor="username">Name</label>
                 </p>
                 <input
-                    disabled={!isConnected}
+                    disabled={!connected}
                     type="text"
                     id="username"
                     maxLength={20}
@@ -878,7 +865,7 @@ export default function FakeArtistRoom() {
                     }}
                 />
                 <button
-                    disabled={!isConnected}
+                    disabled={!connected}
                     onClick={() => {
                         const usernameDom: HTMLInputElement =
                             document.getElementById(

--- a/frontend/src/pages/hideout/[roomId].tsx
+++ b/frontend/src/pages/hideout/[roomId].tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import SockJsClient from 'react-stomp';
 import { SystemConst } from '../../const/next.config';
 import Layout from '../../components/layout';
 import Head from 'next/head';
@@ -18,19 +17,20 @@ import GameInfo from '../../components/hideout/gameinfo';
 import Router from 'next/router';
 import Start from '../../components/timebomb/start';
 import Socialbtn from '../../components/button/sosialbtn';
-
-// 接続切れ
-const disconnect = () => {
-    console.log('接続が切れました');
-};
+import { useGameSocket } from '../../lib/stomp/useGameSocket';
+import ConnectionStatus from '../../components/common/ConnectionStatus';
 
 export default function HideoutRoom() {
     // roomId取得
     const router = useRouter();
     const { roomId } = router.query;
 
-    const [clientObj, setClientObj] = useState(null);
-    const [isConnected, setIsConnected] = useState(false);
+    const { connected, status, send } = useGameSocket({
+        topic: `/topic/${roomId}`,
+        onMessage: (msg) => getMessage(msg),
+        enabled: !!roomId,
+    });
+
     const [messageList, setMessageList] = useState([]);
     const [playerName, setPlayerName] = useState(null);
     const [chatList, setChatList] = useState([]);
@@ -139,12 +139,12 @@ export default function HideoutRoom() {
             };
             conect(url, soketInfo);
         },
-        [clientObj, playerName]
+        [playerName]
     );
 
     const conect = (url: string, soketInfo: SocketInfo) => {
         try {
-            clientObj.sendMessage(url, JSON.stringify(soketInfo));
+            send(url, soketInfo);
         } catch (e) {
             setMessageList(
                 messageList.concat('通信エラー。再度試してください')
@@ -321,26 +321,13 @@ export default function HideoutRoom() {
                     );
                 }
             })}
-            <SockJsClient
-                url={SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT}
-                topics={['/topic/' + roomId]}
-                ref={(client) => {
-                    setClientObj(client);
-                }}
-                onMessage={(msg) => {
-                    getMessage(msg);
-                }}
-                onConnect={() => {
-                    setIsConnected(true);
-                }}
-                onDisconnect={disconnect}
-            />
+            <ConnectionStatus status={status} />
             <div className={styles.roominbtn}>
                 <p>
                     <label htmlFor="username">Name</label>
                 </p>
                 <input
-                    disabled={!isConnected}
+                    disabled={!connected}
                     type="text"
                     id="username"
                     maxLength={20}
@@ -356,7 +343,7 @@ export default function HideoutRoom() {
                     }}
                 />
                 <button
-                    disabled={!isConnected}
+                    disabled={!connected}
                     onClick={() => {
                         const usernameDom: HTMLInputElement =
                             document.getElementById(

--- a/frontend/src/pages/timebomb/[roomId].tsx
+++ b/frontend/src/pages/timebomb/[roomId].tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import SockJsClient from 'react-stomp';
 import { SystemConst } from '../../const/next.config';
 import Layout from '../../components/layout';
 import Start from '../../components/timebomb/start';
@@ -15,20 +14,21 @@ import CountdownClock from '../../components/countdownclock';
 import Router from 'next/router';
 import Head from 'next/head';
 import Socialbtn from '../../components/button/sosialbtn';
-
-// 接続切れ
-const disconnect = () => {
-    console.log('接続が切れました');
-};
+import { useGameSocket } from '../../lib/stomp/useGameSocket';
+import ConnectionStatus from '../../components/common/ConnectionStatus';
 
 export default function Room() {
     // roomId取得
     const router = useRouter();
     const { roomId } = router.query;
 
+    const { connected, status, send } = useGameSocket({
+        topic: `/topic/${roomId}/timebomb`,
+        onMessage: (msg) => receve(msg),
+        enabled: !!roomId,
+    });
+
     // react hooks state
-    const [clientObj, setClientObj] = useState(null);
-    const [isConnected, setIsConnected] = useState(false);
     const [playerName, setPlayerName] = useState('');
     const [timeBombUserList, setTimeBombUserList] = useState([]);
     const [leadCardsList, setLeadCardsList] = useState([]);
@@ -70,7 +70,7 @@ export default function Room() {
 
     const coneect = (url: string, msg: RoomUserInfo) => {
         try {
-            clientObj.sendMessage(url, JSON.stringify(msg));
+            send(url, msg);
         } catch (e) {
             setMessageList(
                 messageList.concat('通信エラー。再度試してください')
@@ -222,7 +222,7 @@ export default function Room() {
             };
             coneect(url, usrInfo);
         },
-        [isConnected, playerName]
+        [playerName]
     );
 
     const limittimeDone = useCallback(
@@ -244,7 +244,7 @@ export default function Room() {
                     obj: pturn,
                 };
                 try {
-                    clientObj.sendMessage(url, JSON.stringify(info));
+                    send(url, info);
                 } catch (e) {
                     // 処理なし
                 }
@@ -264,7 +264,7 @@ export default function Room() {
             obj: time,
         };
 
-        clientObj.sendMessage(url, JSON.stringify(info));
+        send(url, info);
     };
 
     // シークレットモード変更
@@ -278,7 +278,7 @@ export default function Room() {
             obj: null,
         };
 
-        clientObj.sendMessage(url, JSON.stringify(info));
+        send(url, info);
     };
 
     return (
@@ -350,22 +350,7 @@ export default function Room() {
                 }
             })}
 
-            <SockJsClient
-                url={SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT}
-                topics={['/topic/' + roomId + '/timebomb']}
-                ref={(client) => {
-                    setClientObj(client);
-                }}
-                onMessage={(msg) => {
-                    // デバッグ用
-                    // console.log(msg);
-                    receve(msg);
-                }}
-                onConnect={() => {
-                    setIsConnected(true);
-                }}
-                onDisconnect={disconnect}
-            />
+            <ConnectionStatus status={status} />
 
             {turn < 1 && (
                 <div className={styles.roominbtn}>
@@ -373,7 +358,7 @@ export default function Room() {
                         <label htmlFor="username">Name</label>
                     </p>
                     <input
-                        disabled={!isConnected}
+                        disabled={!connected}
                         type="text"
                         id="username"
                         maxLength={20}
@@ -400,7 +385,7 @@ export default function Room() {
                         }}
                     />
                     <button
-                        disabled={!isConnected}
+                        disabled={!connected}
                         onClick={() => {
                             const usernameDom: HTMLInputElement =
                                 document.getElementById(

--- a/frontend/src/pages/werewolf/[roomId].tsx
+++ b/frontend/src/pages/werewolf/[roomId].tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-irregular-whitespace */
 import React from 'react';
 import { useRouter } from 'next/router';
-import SockJsClient from 'react-stomp';
 import { SystemConst } from '../../const/next.config';
 import Layout from '../../components/layout';
 import Head from 'next/head';
@@ -27,11 +26,8 @@ import Modal from '../../components/modal';
 import CircleBtn from '../../components/button/circlebtn';
 import Loadingdod from '../../components/text/loadingdod';
 import Socialbtn from '../../components/button/sosialbtn';
-
-// 接続切れ
-const disconnect = () => {
-    console.log('接続が切れました');
-};
+import { useGameSocket } from '../../lib/stomp/useGameSocket';
+import ConnectionStatus from '../../components/common/ConnectionStatus';
 
 // 情報設定
 const setRollCustum = (rollNoList: Array<number>) => {
@@ -76,8 +72,12 @@ export default function WerewolfRoom() {
     const router = useRouter();
     const { roomId } = router.query;
 
-    const [clientObj, setClientObj] = useState(null);
-    const [isConnected, setIsConnected] = useState(false);
+    const { connected, status, send } = useGameSocket({
+        topic: `/topic/${roomId}`,
+        onMessage: (msg) => getMessage(msg),
+        enabled: !!roomId,
+    });
+
     const [messageList, setMessageList] = useState([]);
     const [playerName, setPlayerName] = useState(null);
     const [chatList, setChatList] = useState([]);
@@ -136,7 +136,7 @@ export default function WerewolfRoom() {
             };
             conect(url, soketInfo);
         },
-        [clientObj, playerName]
+        [playerName]
     );
 
     // チャット
@@ -316,7 +316,7 @@ export default function WerewolfRoom() {
 
     const conect = (url: string, soketInfo: SocketInfo) => {
         try {
-            clientObj.sendMessage(url, JSON.stringify(soketInfo));
+            send(url, soketInfo);
         } catch (e) {
             setMessageList(
                 messageList.concat('通信エラー。再度試してください')
@@ -714,20 +714,7 @@ export default function WerewolfRoom() {
                     );
                 }
             })}
-            <SockJsClient
-                url={SystemConst.Server.AP_HOST + SystemConst.Server.ENDPOINT}
-                topics={['/topic/' + roomId]}
-                ref={(client) => {
-                    setClientObj(client);
-                }}
-                onConnect={() => {
-                    setIsConnected(true);
-                }}
-                onMessage={(msg) => {
-                    getMessage(msg);
-                }}
-                onDisconnect={disconnect}
-            />
+            <ConnectionStatus status={status} />
             <div className={styles.roominbtn}>
                 <p>
                     <label htmlFor="username">Name</label>
@@ -747,7 +734,7 @@ export default function WerewolfRoom() {
                             roomIn(usernameDom.value);
                         }
                     }}
-                    disabled={!isConnected}
+                    disabled={!connected}
                 />
                 <button
                     onClick={() => {
@@ -757,7 +744,7 @@ export default function WerewolfRoom() {
                             ) as HTMLInputElement;
                         roomIn(usernameDom.value);
                     }}
-                    disabled={!isConnected}
+                    disabled={!connected}
                 >
                     Room IN
                 </button>

--- a/frontend/src/styles/components/common/connectionstatus.module.scss
+++ b/frontend/src/styles/components/common/connectionstatus.module.scss
@@ -1,0 +1,12 @@
+.banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    padding: 6px 12px;
+    text-align: center;
+    font-size: 13px;
+    color: #fff;
+    background: rgba(180, 90, 90, 0.92);
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+    },
+});


### PR DESCRIPTION
## 概要
メンテ終了の `react-stomp` を `@stomp/stompjs` v7 + `sockjs-client` に置換し、型付き共通フック `useGameSocket` に集約しました。バックエンド(Java/Spring, SockJS+STOMP)は無変更で互換維持。

- 設計: `docs/superpowers/specs/2026-07-04-stage2-communication-design.md`
- 計画: `docs/superpowers/plans/2026-07-04-stage2-communication.md`

## 変更内容
- **`useGameSocket` フック**(`src/lib/stomp/`)+ ユニットテスト8件(接続・購読・送信・JSON parse・再接続時の重複購読防止)
- **接続インジケータ `ConnectionStatus`**(再接続中/切断時のみ控えめ表示、自動再接続 `reconnectDelay`)
- **5ゲームを移行**(timebomb/werewolf/hideout/decrypt/fakeartist)。各ページの `SockJsClient`(JSX)+ `clientObj`/`isConnected` state を `useGameSocket` の `status`/`connected`/`send` に置換。受信ハンドラ(`receve`/`getMessage`)は無変更(reducer化はStage 3)
- 送信を `send(destination, payload)` に統一(`JSON.stringify` はフック内部で1回のみ=二重エンコード防止)
- **`react-stomp` を依存から削除**

## 検証
- テスト11件PASS / lint error 0 / build成功(Node 22系、OpenSSLフラグ不要)/ `src` にreact-stomp残骸0
- 全5ゲームが本番Herokuへ `useGameSocket` 経由で接続・コンソールエラーなしをブラウザ確認(timebombは入室往復も)
- ユーザーから見た挙動は不変(接続インジケータ追加のみ)

## 手動確認おすすめ(ヘッドレスで未検証)
- **実ネットワーク断での自動再接続**(wifiオフ→オン等で「再接続中…」バナー表示→自動復帰)。再接続ロジック自体はユニットテスト済み
- 接続インジケータ(`z-index:9999` の一時バナー)がモーダルと重なって見えないかの目視

## マージ後
Vercel Root Directory は `frontend` 設定済みのため、master マージで自動デプロイされます(カットオーバー不要)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)