### PR TITLE
Webフォント読込を head link 化(#82マージ後に取り残された修正)

### DIFF
--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -13,6 +13,23 @@ class DocumentTsx extends Document {
         return (
             <Html lang="ja">
                 <Head>
+                    <link
+                        rel="preconnect"
+                        href="https://fonts.googleapis.com"
+                    />
+                    <link
+                        rel="preconnect"
+                        href="https://fonts.gstatic.com"
+                        crossOrigin=""
+                    />
+                    <link
+                        rel="stylesheet"
+                        href="https://fonts.googleapis.com/css?family=Patrick+Hand+SC&display=swap"
+                    />
+                    <link
+                        rel="stylesheet"
+                        href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500&display=swap"
+                    />
                     <meta name="mobile-web-app-capable" content="yes" />
                     <meta name="apple-mobile-web-app-capable" content="yes" />
                     <link

--- a/frontend/src/styles/components/button/imagepulsingbtn.module.scss
+++ b/frontend/src/styles/components/button/imagepulsingbtn.module.scss
@@ -1,5 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Patrick+Hand+SC);
-
 .non_view {
     opacity: 0;
     transition: opacity 0.5s;

--- a/frontend/src/styles/components/button/pulsingbutton.module.scss
+++ b/frontend/src/styles/components/button/pulsingbutton.module.scss
@@ -1,5 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Patrick+Hand+SC);
-
 .non_view {
     opacity: 0;
     transition: opacity 0.5s;

--- a/frontend/src/styles/components/timebomb/start.module.scss
+++ b/frontend/src/styles/components/timebomb/start.module.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500&display=swap');
-
 div.start {
     font-family: 'Montserrat', sans-serif;
     background: #fff;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -1,4 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Patrick+Hand+SC);
 html,
 body {
     overflow-x: visible;


### PR DESCRIPTION
## 概要

PR #82 は `9662999` の時点でマージされたため、その後に push した**Web フォント修正コミット `38641ea` が master に取り込まれていません**。本 PR はその1コミットだけを master に反映します。

## 内容

Web フォント(Patrick Hand SC / Montserrat)の読み込みを CSS `@import` から `_document.tsx` の `<head>` の `<link>` へ移行。本番ビルドで CSS が連結されると `@import` が先頭以外に回りブラウザに無視されるため、本番でボタンが cursive / sans-serif にフォールバックしていた不具合の修正。

詳細な検証は #82 のコメント参照(build 成功 / lint error 0 / 本番ビルドの生成CSSに @import 残存なし / head に link 出力を確認)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)