### PR TITLE
werewolf UI刷新一式(LP統合・ゲーム中画面・待機/終了画面リデザイン)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; case \"$f\" in */frontend/src/*.ts|*/frontend/src/*.tsx) (cd \"$CLAUDE_PROJECT_DIR/frontend\" && npx prettier --write \"$f\" && npx eslint --fix \"$f\") ;; esac; } 2>/dev/null || true",
+            "statusMessage": "frontend を整形中 (prettier + eslint)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Thumbs.db
+.playwright-mcp

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}

--- a/frontend/src/styles/components/werewolf/userinfo.module.scss
+++ b/frontend/src/styles/components/werewolf/userinfo.module.scss
@@ -55,16 +55,18 @@ $animetiondelay: 2s;
 .enter {
     animation: norenIn 0.6s $ease both;
 }
+/* fill-mode both で最終値が残留するため、クリップ領域は負の inset で
+   カード外にはみ出す要素(浮遊アバター・YOUバッジ・発光)まで含めておく */
 @keyframes norenIn {
     from {
         opacity: 0;
         transform: translateY(14px);
-        clip-path: inset(0 0 100% 0);
+        clip-path: inset(-80px -24px 100% -24px);
     }
     to {
         opacity: 1;
         transform: translateY(0);
-        clip-path: inset(0 0 0 0);
+        clip-path: inset(-80px -24px -48px -24px);
     }
 }
 


### PR DESCRIPTION
## 概要

セカンドワンナイト人狼の UI を全面刷新し、LP と統一した夜系デザインに再構築する。

## 主な変更

### LP・デザイン基盤
- werewolf のデザインを LP に統合し、ルーム作成・入室機能を追加
- デザイントークン(`tokens.scss`)を共通化し、背景・モーダルを刷新
- カスタムアイコン(写真アップロード)と退出・キック機能を実装

### ゲーム中画面
- 役職選択・議論・投票フェーズの背景を夜系(dusk/dawn)に統一・拡張
- プレイヤーカード UI を再設計(IconPicker・フェーズ帯・名前の段階縮小・YOU タブ)
- メッセージ帯・カットイン・役職セットをトークンベースに統一
- 役職選択の DOM 直接操作を `useBodyClass` と state 導出に置き換え

### 勝利演出・終了画面
- 勝利演出を3幕構成(種明かし → 勝敗発表 → 結果一覧)に再編
- 巻物風 ResultScroll・DeadMarker・SakuraParticles を追加

### 待機画面(宵の口構成)
- 招待カード刷新・提灯列(入室数表示)・お品書きパネル(設定UI統合)を追加
- 待機カードに登場・つつき演出を追加
- 登場演出の clip-path 残留でアバター・YOU バッジが見切れる問題を修正

### ドキュメント・開発環境
- 設計書・実装計画の追加と architecture への反映、roadmap 整理
- frontend 系スキル(baseline-ui / frontend-design ほか)と MCP 設定を追加

## 検証

- `npm test`(154件)/ `npm run lint`(error 0)/ `npm run build` すべて成功
- 本番 Heroku 接続でルーム作成 → 2人入室 → 待機画面をデスクトップ・モバイル幅で確認(コンソールエラー 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)